### PR TITLE
Also run tests on non-UTC time zones.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,26 @@ on:
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} (TZ = ${{ matrix.env.TZ }})
     runs-on: ubuntu-20.04
 
     strategy:
       matrix:
         python-version:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10-dev
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+          - 3.10-dev
+        env:
+          - TZ: "UTC"
+        include:
+          - python-version: 3.9
+            env:
+              TZ: "America/New_York"
+          - python-version: 3.9
+            env:
+              TZ: "Australia/Sydney"
 
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +42,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+
+    - name: Set time zone
+      run: |
+        sudo timedatectl set-timezone ${{ matrix.env.TZ }}
 
     - name: Install dependencies
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel -m pytest {posargs}
+passenv = TZ
 
 [testenv:py36]
 deps = -rrequirements/py36.txt


### PR DESCRIPTION
The tests are currently failing for non-UTC time zones because of some
assumptions related to `time.localtime`. The test suite should pass when
run on developer machines, which aren't usually set to UTC, so add
explicit cases to the testing matrix to ensure that once the issue is
fixed, it will not have regressions.